### PR TITLE
upstart: create log directory from ansible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
     -   id: check-json
     -   id: end-of-file-fixer
 -   repo: https://github.com/willthames/ansible-lint.git
-    sha: v3.4.13
+    sha: v3.4.15
     hooks:
     -   id: ansible-lint
         files: \.(yaml|yml)$

--- a/tasks/service-upstart.yml
+++ b/tasks/service-upstart.yml
@@ -1,4 +1,14 @@
 ---
+
+- name: create logdir
+  become: true
+  file:
+    path: "{{ node_exporter_log_path }}"
+    owner: "{{ node_exporter_user }}"
+    group: "{{ node_exporter_group }}"
+    state: directory
+    mode: 0750
+  
 - name: upstart service
   become: true
   template:

--- a/tasks/service-upstart.yml
+++ b/tasks/service-upstart.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: create logdir
   become: true
   file:
@@ -8,7 +7,7 @@
     group: "{{ node_exporter_group }}"
     state: directory
     mode: 0750
-  
+
 - name: upstart service
   become: true
   template:

--- a/templates/node_exporter.upstart.j2
+++ b/templates/node_exporter.upstart.j2
@@ -13,12 +13,6 @@ env logdir={{ node_exporter_log_path }}
 env user={{ node_exporter_user }}
 env group={{ node_exporter_group }}
 
-pre-start script
-  mkdir -p $logdir || true
-  chmod 0750 $logdir || true
-  chown $user:$group $logdir || true
-end script
-
 script
   if [ -f "{{ node_exporter_config_file }}" ] ; then
     . "{{ node_exporter_config_file }}"


### PR DESCRIPTION
This PR aims to fix the following issue encountered on some ubuntu 14.04:
`mkdir: cannot create directory '/var/log/node_exporter': Permission denied`

This error occurs because the pre-start script in upstart is run with node_exporter_user:node_exporter_group instead of root:root.

The fix move the log directory creation in ansible instead.