### PR TITLE
Update node_exporter to 0.15

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 node_exporter_user:   node_exporter
 node_exporter_group:  node_exporter
 
-node_exporter_version: "0.14.0"
-node_exporter_tarball_checksum: "sha1:7f268a8327a4b1b9137176389f4ee841dae88d2e"
+node_exporter_version: "0.15.2"
+node_exporter_tarball_checksum: "sha1:3b8d048c306dfec002d61819fd39c5d066ca9f01"
 node_exporter_platform_suffix: "linux-amd64"
 
 node_exporter_signature: "node_exporter-{{ node_exporter_version }}.{{ node_exporter_platform_suffix }}"

--- a/templates/node_exporter.default.conf.j2
+++ b/templates/node_exporter.default.conf.j2
@@ -1,1 +1,1 @@
-OPTIONS="-collector.textfile.directory {{ node_exporter_home }} {{ node_exporter_options | join(', ') }}"
+OPTIONS="--collector.textfile.directory {{ node_exporter_home }} {{ node_exporter_options | join(', ') }}"


### PR DESCRIPTION
Options needed to be changed as well as otherwise, the error is reported:
```
node_exporter[23203]: node_exporter: error: unknown short flag '-c', try --help
```